### PR TITLE
token name change for action colors.

### DIFF
--- a/tokens/comp/button.json
+++ b/tokens/comp/button.json
@@ -72,19 +72,19 @@
       "accentButton": {
         "bg": {
           "idle": {
-            "value": "{semantic.color.action.accent.idle}",
+            "value": "{semantic.color.action.primaryAccent.idle}",
             "type": "color"
           },
           "hover": {
-            "value": "{semantic.color.action.accent.hover}",
+            "value": "{semantic.color.action.primaryAccent.hover}",
             "type": "color"
           },
           "press": {
-            "value": "{semantic.color.action.accent.press}",
+            "value": "{semantic.color.action.primaryAccent.press}",
             "type": "color"
           },
           "focus": {
-            "value": "{semantic.color.action.accent.focus}",
+            "value": "{semantic.color.action.primaryAccent.focus}",
             "type": "color"
           }
         },

--- a/tokens/semantic/color.json
+++ b/tokens/semantic/color.json
@@ -2,7 +2,7 @@
   "semantic": {
     "color": {
       "action": {
-        "accent": {
+        "primaryAccent": {
           "idle": {
             "value": "{color.default.blue-2.500}",
             "type": "color",
@@ -21,7 +21,7 @@
             "type": "color"
           }
         },
-        "default": {
+        "defaultAccent": {
           "idle": {
             "value": "{color.default.violet-1.500}",
             "type": "color",
@@ -286,19 +286,19 @@
       "selected": {
         "bg": {
           "idle": {
-            "value": "{semantic.color.action.default.idle}",
+            "value": "{semantic.color.action.defaultAccent.idle}",
             "type": "color"
           },
           "hover": {
-            "value": "{semantic.color.action.default.hover}",
+            "value": "{semantic.color.action.defaultAccent.hover}",
             "type": "color"
           },
           "press": {
-            "value": "{semantic.color.action.default.press}",
+            "value": "{semantic.color.action.defaultAccent.press}",
             "type": "color"
           },
           "focus": {
-            "value": "{semantic.color.action.default.focus}",
+            "value": "{semantic.color.action.defaultAccent.focus}",
             "type": "color"
           }
         },
@@ -322,19 +322,19 @@
         },
         "border-color": {
           "idle": {
-            "value": "{semantic.color.action.default.idle}",
+            "value": "{semantic.color.action.defaultAccent.idle}",
             "type": "color"
           },
           "hover": {
-            "value": "{semantic.color.action.default.hover}",
+            "value": "{semantic.color.action.defaultAccent.hover}",
             "type": "color"
           },
           "press": {
-            "value": "{semantic.color.action.default.press}",
+            "value": "{semantic.color.action.defaultAccent.press}",
             "type": "color"
           },
           "focus": {
-            "value": "{semantic.color.action.default.focus}",
+            "value": "{semantic.color.action.defaultAccent.focus}",
             "type": "color"
           }
         },

--- a/tokens/theme/b2b.json
+++ b/tokens/theme/b2b.json
@@ -2,7 +2,7 @@
   "semantic": {
     "color": {
       "action": {
-        "accent": {
+        "primaryAccent": {
           "idle": {
             "value": "{color.extended.blue-4.600}",
             "type": "color",
@@ -21,7 +21,7 @@
             "type": "color"
           }
         },
-        "default": {
+        "defaultAccent": {
           "idle": {
             "value": "{color.extended.blue-4.600}",
             "type": "color",

--- a/tokens/theme/b2c-v3.json
+++ b/tokens/theme/b2c-v3.json
@@ -2,7 +2,7 @@
   "semantic": {
     "color": {
       "action": {
-        "accent": {
+        "primaryAccent": {
           "idle": {
             "value": "{color.default.red-1.500}",
             "type": "color",
@@ -24,7 +24,7 @@
             "description": "Focus state of primary accent color"
           }
         },
-        "default": {
+        "defaultAccent": {
           "idle": {
             "value": "{color.default.teal-1.500}",
             "type": "color",

--- a/tokens/theme/b2c.json
+++ b/tokens/theme/b2c.json
@@ -2,7 +2,7 @@
   "semantic": {
     "color": {
       "action": {
-        "accent": {
+        "primaryAccent": {
           "idle": {
             "value": "{color.default.red-1.500}",
             "type": "color",
@@ -21,7 +21,7 @@
             "type": "color"
           }
         },
-        "default": {
+        "defaultAccent": {
           "idle": {
             "value": "{color.default.teal-1.500}",
             "type": "color",


### PR DESCRIPTION
Action token names are a little more semantic now. action.primaryAccent and action.defaultAccent. 

I think this maybe makes it more clear what the intended use of the color is. This also make it a little more scaleable if we want to add other accent colors. Something like: action.accent-1