### PR TITLE
Added semantic token for buttons fontFamily. 

### DIFF
--- a/tokens/semantic/typography.json
+++ b/tokens/semantic/typography.json
@@ -503,7 +503,7 @@
         "normal": {
           "regular": {
             "value": {
-              "fontFamily": "{fontFamilies.body}",
+              "fontFamily": "{fontFamilies.buttons}",
               "fontWeight": "{fontWeights.body.regular}",
               "lineHeight": "{lineHeights.body.default}",
               "fontSize": "{fontSize.sm}",
@@ -516,7 +516,7 @@
           },
           "strong": {
             "value": {
-              "fontFamily": "{fontFamilies.body}",
+              "fontFamily": "{fontFamilies.buttons}",
               "fontWeight": "{fontWeights.body.strong}",
               "lineHeight": "{lineHeights.body.default}",
               "fontSize": "{fontSize.sm}",
@@ -531,7 +531,7 @@
         "large": {
           "regular": {
             "value": {
-              "fontFamily": "{fontFamilies.body}",
+              "fontFamily": "{fontFamilies.buttons}",
               "fontWeight": "{fontWeights.body.regular}",
               "lineHeight": "{lineHeights.body.default}",
               "fontSize": "{fontSize.md}",
@@ -544,7 +544,7 @@
           },
           "strong": {
             "value": {
-              "fontFamily": "{fontFamilies.body}",
+              "fontFamily": "{fontFamilies.buttons}",
               "fontWeight": "{fontWeights.body.strong}",
               "lineHeight": "{lineHeights.body.default}",
               "fontSize": "{fontSize.md}",
@@ -559,7 +559,7 @@
         "xLarge": {
           "regular": {
             "value": {
-              "fontFamily": "{fontFamilies.body}",
+              "fontFamily": "{fontFamilies.buttons}",
               "fontWeight": "{fontWeights.body.regular}",
               "lineHeight": "{lineHeights.body.default}",
               "fontSize": "{fontSize.xl}",
@@ -572,7 +572,7 @@
           },
           "strong": {
             "value": {
-              "fontFamily": "{fontFamilies.body}",
+              "fontFamily": "{fontFamilies.buttons}",
               "fontWeight": "{fontWeights.body.strong}",
               "lineHeight": "{lineHeights.body.default}",
               "fontSize": "{fontSize.xl}",
@@ -680,6 +680,10 @@
   "fontFamilies": {
     "headlines": {
       "value": "{fontFamilies.Roboto Slab}",
+      "type": "fontFamilies"
+    },
+    "buttons": {
+      "value": "{fontFamilies.Roboto}",
       "type": "fontFamilies"
     },
     "body": {

--- a/tokens/theme/b2c-v3.json
+++ b/tokens/theme/b2c-v3.json
@@ -51,6 +51,10 @@
       "value": "Sofia Pro",
       "type": "fontFamilies"
     },
+    "buttons": {
+      "value": "Sofia Pro",
+      "type": "fontFamilies"
+    },
     "body": {
       "value": "FreightDisp Pro",
       "type": "fontFamilies"


### PR DESCRIPTION
Added the corresponding token the the B2C-V3 theme set, and updated the semantic button typography to reference the new fontFamily. This means that button labels can be sans-serif (or serif) but they are independent from the body or headline fontFamilies