### PR TITLE
changed name of global color scale:

### DIFF
--- a/tokens/global/color.json
+++ b/tokens/global/color.json
@@ -511,7 +511,7 @@
           }
         }
       },
-      "neutral-1-inverse": {
+      "inverse-neutral-1": {
         "50": {
           "value": "rgba({color.default.white}, 0.08)",
           "type": "color"

--- a/tokens/semantic/color.json
+++ b/tokens/semantic/color.json
@@ -238,26 +238,26 @@
               "type": "color"
             },
             "regular": {
-              "value": "{color.default.neutral-1-inverse.600}",
+              "value": "{color.default.inverse-neutral-1.600}",
               "type": "color"
             },
             "subdued": {
-              "value": "{color.default.neutral-1-inverse.400}",
+              "value": "{color.default.inverse-neutral-1.400}",
               "type": "color"
             },
             "decorative": {
-              "value": "{color.default.neutral-1-inverse.100}",
+              "value": "{color.default.inverse-neutral-1.100}",
               "type": "color"
             }
           },
           "bg": {
             "surface-lightest": {
-              "value": "{color.default.neutral-1-inverse.100}",
+              "value": "{color.default.inverse-neutral-1.100}",
               "type": "color",
               "description": "Lorem…"
             },
             "surface-light": {
-              "value": "{color.default.neutral-1-inverse.200}",
+              "value": "{color.default.inverse-neutral-1.200}",
               "type": "color"
             },
             "canvas": {


### PR DESCRIPTION
neutral-1-inverse is now inverse-neutral-1. This matches more closely to how the semantic token organize. where inverse is a kind of category, not just a modifier